### PR TITLE
Override LRScheduler when using LRModifiers

### DIFF
--- a/src/transformers/sparse.py
+++ b/src/transformers/sparse.py
@@ -102,6 +102,24 @@ class SparseMLTrainer(Trainer):
                 self.optimizer, self.model, self.manager, steps_per_epoch=steps_per_epoch, loggers=self.loggers
             )
 
+    def create_scheduler(self, num_training_steps: int):
+        """
+        Override LR scheduler if the SparseML manager has LR modifiers, otherwise
+        set default scheduler
+        """
+        if self.lr_scheduler is not None:
+            # scheduler already set
+            return
+
+        if self.manager.learning_rate_modifiers:
+            # allow SparseML to manage LR and set a dummy scheduler
+            self.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(
+                self.optimizer, lambda _: 1.0, -1
+            )
+        else:
+            # default scheduler
+            super().create_scheduler(num_training_steps)
+
     def save_model(self, output_dir: Optional[str] = None):
         """
         Save model during or after training. The sparsification recipe will also be saved.


### PR DESCRIPTION
to perform pruning and QAT phases in the same recipe, it is useful to control the LR schedule within the recipe. currently, the HF LR scheduler will be called after the sparseml step, overriding any LR Modifiers. This PR detects if there are any LR modifiers in a Trainer's recipe, and if so, sets the HF LR scheduler to a dummy one.

example LR schedule recipe for pruning+QAT:
```yaml
training_modifiers:
  - !EpochRangeModifier
    end_epoch: *num_epochs
    start_epoch: 0.0
    
  - !LearningRateFunctionModifier
    start_epoch: 0.0
    end_epoch: *quantization_start_epoch
    lr_func: linear
    init_lr: *init_lr
    final_lr: 0.0
    
  # reset LR schedule for QAT
  - !LearningRateFunctionModifier
    start_epoch: *quantization_start_epoch
    end_epoch: *num_epochs
    lr_func: linear
    init_lr: *init_lr
    final_lr: 0.0
```

Produced schedule from W&B:
<img width="440" alt="Screen Shot 2021-08-30 at 4 40 38 PM" src="https://user-images.githubusercontent.com/11316925/131403000-01d5acb9-4114-4ce1-a84b-27f8f6a8c6b3.png">

W&B: https://wandb.ai/neuralmagic/huggingface/runs/40ycsv8g?workspace=user-neuralmagic