### PR TITLE
Disable FP16 on QAT start

### DIFF
--- a/src/transformers/sparse.py
+++ b/src/transformers/sparse.py
@@ -102,6 +102,24 @@ class SparseMLTrainer(Trainer):
                 self.optimizer, self.model, self.manager, steps_per_epoch=steps_per_epoch, loggers=self.loggers
             )
 
+    def create_scheduler(self, num_training_steps: int):
+        """
+        Override LR scheduler if the SparseML manager has LR modifiers, otherwise
+        set default scheduler
+        """
+        if self.lr_scheduler is not None:
+            # scheduler already set
+            return
+
+        if self.manager.learning_rate_modifiers:
+            # allow SparseML to manage LR and set a dummy scheduler
+            self.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(
+                self.optimizer, lambda _: 1.0, -1
+            )
+        else:
+            # default scheduler
+            super().create_scheduler(num_training_steps)
+
     def save_model(self, output_dir: Optional[str] = None):
         """
         Save model during or after training. The sparsification recipe will also be saved.

--- a/src/transformers/sparse.py
+++ b/src/transformers/sparse.py
@@ -120,6 +120,14 @@ class SparseMLTrainer(Trainer):
             # default scheduler
             super().create_scheduler(num_training_steps)
 
+    def qat_active(self, epoch: int):
+        if not self.manager.quantization_modifiers:
+            return False
+
+        qat_start = min([mod.start_epoch for mod in self.manager.quantization_modifiers])
+
+        return qat_start < epoch + 1
+
     def save_model(self, output_dir: Optional[str] = None):
         """
         Save model during or after training. The sparsification recipe will also be saved.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1217,7 +1217,7 @@ class Trainer:
         for epoch in range(epochs_trained, num_train_epochs):
             if self.use_amp and hasattr(self, "qat_active") and callable(self.qat_active) and self.qat_active(epoch):
                 logger.info("entering QAT phase, disabling FP16 training")
-                self.use_amp = False
+                self.scaler._enabled = False
 
             if isinstance(train_dataloader, DataLoader) and isinstance(train_dataloader.sampler, DistributedSampler):
                 train_dataloader.sampler.set_epoch(epoch)
@@ -1736,7 +1736,7 @@ class Trainer:
             return loss_mb.reduce_mean().detach().to(self.args.device)
 
         if self.use_amp:
-            with autocast():
+            with autocast(enabled=self.scaler.is_enabled()):
                 loss = self.compute_loss(model, inputs)
         else:
             loss = self.compute_loss(model, inputs)
@@ -2381,7 +2381,7 @@ class Trainer:
                 else:
                     loss = None
                     if self.use_amp:
-                        with autocast():
+                        with autocast(enabled=self.scaler.is_enabled()):
                             outputs = model(**inputs)
                     else:
                         outputs = model(**inputs)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1215,6 +1215,10 @@ class Trainer:
                     break
 
         for epoch in range(epochs_trained, num_train_epochs):
+            if self.use_amp and hasattr(self, "qat_active") and callable(self.qat_active) and self.qat_active(epoch):
+                logger.info("entering QAT phase, disabling FP16 training")
+                self.use_amp = False
+
             if isinstance(train_dataloader, DataLoader) and isinstance(train_dataloader.sampler, DistributedSampler):
                 train_dataloader.sampler.set_epoch(epoch)
             elif isinstance(train_dataloader.dataset, IterableDatasetShard):


### PR DESCRIPTION
tested with a full block prune -> QAT recipe (running with 5 steps per epoch) with QAT enabled at epoch 30 and FP16 initially enabled by the script. test run finished successfully with the following log on QAT start:

`[INFO|trainer.py:1219] 2021-08-30 17:06:29,154 >> entering QAT phase, disabling FP16 training`
https://wandb.ai/neuralmagic/huggingface/runs/12czmywr?workspace=user-neuralmagic