### PR TITLE
Fix missing enabled param

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -181,7 +181,7 @@ class Seq2SeqTrainer(Trainer):
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_kwargs["max_length"])
 
         with torch.no_grad():
-            with self.autocast_smart_context_manager():
+            with self.autocast_smart_context_manager(enabled=hasattr(self, "scaler") and self.scaler.is_enabled()):
                 outputs = model(**inputs)
             if has_labels:
                 if self.label_smoother is not None:


### PR DESCRIPTION
Running summarization examples breaks because autocast context is missing enabled param.