### PR TITLE
Best model after epoch

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1725,7 +1725,12 @@ class Trainer:
                 torch.save(self.scaler.state_dict(), os.path.join(output_dir, SCALER_NAME))
 
         # Determine the new best metric / best model checkpoint
-        if metrics is not None and self.args.metric_for_best_model is not None:
+        if (
+            metrics is not None
+            and self.args.metric_for_best_model is not None
+            and self.args.best_model_after_epoch is not None
+            and self.state.epoch > self.args.best_model_after_epoch
+        ):
             metric_to_check = self.args.metric_for_best_model
             if not metric_to_check.startswith("eval_"):
                 metric_to_check = f"eval_{metric_to_check}"
@@ -2436,11 +2441,7 @@ class Trainer:
         observed_num_examples = 0
         # Main evaluation loop
         for step, inputs in enumerate(dataloader):
-            inputs = {
-                k: inputs[k]
-                for k in inputs
-                if k in list(inspect.signature(model.forward).parameters.keys())
-            }
+            inputs = {k: inputs[k] for k in inputs if k in list(inspect.signature(model.forward).parameters.keys())}
 
             # Update the observed num examples
             observed_batch_size = find_batch_size(inputs)
@@ -2660,7 +2661,9 @@ class Trainer:
                     logits = smp_nested_concat(logits_mb)
             else:
                 if has_labels:
-                    with self.autocast_smart_context_manager(enabled=hasattr(self, "scaler") and self.scaler.is_enabled()):
+                    with self.autocast_smart_context_manager(
+                        enabled=hasattr(self, "scaler") and self.scaler.is_enabled()
+                    ):
                         loss, outputs = self.compute_loss(model, inputs, return_outputs=True)
                     loss = loss.mean().detach()
 
@@ -2670,7 +2673,9 @@ class Trainer:
                         logits = outputs[1:]
                 else:
                     loss = None
-                    with self.autocast_smart_context_manager(enabled=hasattr(self, "scaler") and self.scaler.is_enabled()):
+                    with self.autocast_smart_context_manager(
+                        enabled=hasattr(self, "scaler") and self.scaler.is_enabled()
+                    ):
                         outputs = model(**inputs)
                     if isinstance(outputs, dict):
                         logits = tuple(v for k, v in outputs.items() if k not in ignore_keys)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -640,6 +640,10 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Whether or not to load the best model found during training at the end of training."},
     )
+    best_model_after_epoch: int = field(
+        default=None,
+        metadata={"help": "Epoch after which best model will be saved."},
+    )
     metric_for_best_model: Optional[str] = field(
         default=None, metadata={"help": "The metric to use to compare two different models."}
     )
@@ -748,12 +752,8 @@ class TrainingArguments:
         metadata={"help": "Used by the SageMaker launcher to send mp-specific args. Ignored in Trainer"},
     )
     modifier_log_frequency: float = field(
-        default = 0.1,
-        metadata={
-            "help": (
-                "How often to log SparseML modifier data, in number of epochs or fraction of epochs"
-            )
-        }
+        default=0.1,
+        metadata={"help": ("How often to log SparseML modifier data, in number of epochs or fraction of epochs")},
     )
 
     def __post_init__(self):


### PR DESCRIPTION
This change introduces an option to specify an epoch after which the best model could be saved, and it could be used in conjunction with the existing flags "metric_for_best_model" and "load_best_model_at_end". A use case here is that when doing pruning or transferring followed by quantization, one might use this flag to obtain the best quantized model (which is only valid after the pruning/transferring ends).