### PR TITLE
update build versions for NM fork pypi push

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -406,9 +406,14 @@ install_requires = [
     deps["tqdm"],  # progress bars in model download and training scripts
 ]
 
+# default variable to be overwritten by the version.py file
+version = "unknown"
+# load and overwrite version and release info from version.py
+exec(open(os.path.join("src", "transformers", "version.py")).read())
+
 setup(
-    name="transformers",
-    version="4.23.1",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+    name="nm-transformers",
+    version=version,  # major.minor.patch to match NM repos, fourth entry is either transformers base version or nightly date
     author="The Hugging Face team (past and future) with the help of all our contributors (https://github.com/huggingface/transformers/graphs/contributors)",
     author_email="transformers@huggingface.co",
     description="State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow",
@@ -416,7 +421,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords="NLP vision speech deep learning transformer pytorch tensorflow BERT GPT-2 Wav2Vec2 ViT",
     license="Apache",
-    url="https://github.com/huggingface/transformers",
+    url="https://github.com/neuralmagic/transformers",
     package_dir={"": "src"},
     packages=find_packages("src"),
     package_data={"transformers": ["py.typed", "*.cu", "*.cpp", "*.cuh", "*.h"]},

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -22,7 +22,7 @@
 # to defer the actual importing for when the objects are requested. This way `import transformers` provides the names
 # in the namespace without actually importing anything (and especially none of the backends).
 
-__version__ = "4.23.1"
+from .version import *
 
 from typing import TYPE_CHECKING
 

--- a/src/transformers/version.py
+++ b/src/transformers/version.py
@@ -1,0 +1,39 @@
+"""
+Functionality for storing and setting the version info for SparseML
+"""
+
+from datetime import date
+
+
+nm_version_base = "1.5.0"
+transformers_version_base = "42301"  # 4.23.1
+is_release = False  # change to True to set the generated version as a release version
+
+
+def _generate_version():
+    return (
+        f"{nm_version_base}.{transformers_version_base}"
+        if is_release
+        else f"{nm_version_base}.{date.today().strftime('%Y%m%d')}"
+    )
+
+
+__all__ = [
+    "__version__",
+    "nm_version_base",
+    "transformers_version_base",
+    "is_release",
+    "version",
+    "version_major",
+    "version_minor",
+    "version_bug",
+    "version_build",
+    "version_major_minor",
+]
+__version__ = _generate_version()
+
+version = __version__
+version_major, version_minor, version_bug, version_build = version.split(".") + (
+    [None] if len(version.split(".")) < 4 else []
+)  # handle conditional for version being 3 parts or 4 (4 containing build date)
+version_major_minor = f"{version_major}.{version_minor}"


### PR DESCRIPTION
moving forward build versions will by synced with the latest NM release (patch version is async) with the fourth slot either the nightly date for nightly or the base transformers version for release

example nightly: `1.5.0.20230331`
example release: `1.5.0.42301`