### PR TITLE
add GHA workflow files to build nightly and release packages

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,33 @@
+name: build-package
+run-name: ${{ github.workflow }} is to create wheel file for pypi
+on:
+  push:
+    branches:
+      - 'main'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build-nightly:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::498127099666:role/WebIdentity-nm-github-actions-only
+          aws-region: us-east-1
+      - uses: actions/checkout@v3
+      - run: | 
+             pwd
+             sudo apt-get install python3-pip
+             pip3 --version
+             sudo pip3 install virtualenv
+             virtualenv venv
+             source venv/bin/activate
+             pip install -e .
+             make -B build
+             deactivate
+             ls dist/
+             aws s3 ls s3://nm-github-actions/
+             aws s3 cp dist/*nightly*.whl s3://nm-github-actions/transformers/

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,5 +1,5 @@
-name: build-package
-run-name: ${{ github.workflow }} is to create wheel file for pypi
+name: build-nightly
+run-name: ${{ github.workflow }} is to create nightly wheel file for pypi
 on:
   push:
     branches:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,33 @@
+name: build-package
+run-name: ${{ github.workflow }} is to create wheel file for pypi
+on:
+  push:
+    branches:
+      - 'release/[0-9]+.[0-9]+'
+      
+jobs:
+  build-release:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::498127099666:role/WebIdentity-nm-github-actions-only
+          aws-region: us-east-1
+      - uses: actions/checkout@v3
+      - run: | 
+             pwd
+             sudo apt-get install python3-pip
+             pip3 --version
+             sudo pip3 install virtualenv
+             virtualenv venv
+             source venv/bin/activate
+             pip install -e .
+             sed -i 's/is_release = False/is_release = True/g' src/transformers/version.py
+             make -B build
+             deactivate
+             ls dist/
+             aws s3 ls s3://nm-github-actions/
+             aws s3 cp dist/*.whl s3://nm-github-actions/transformers/

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,5 @@
-name: build-package
-run-name: ${{ github.workflow }} is to create wheel file for pypi
+name: build-release
+run-name: ${{ github.workflow }} is to create release wheel file for pypi
 on:
   push:
     branches:


### PR DESCRIPTION
Add workflow files to build nightly and release packages for NM transformers.

Builds are pushed to S3 s3://nm-github-actions/transformers/

Another Jenkins job or workflow (maybe from another private repo) will publish the builds to internal and external PyPI for safety reason.


