### PR TITLE
OPT with quantizable MatMuls

### DIFF
--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -124,6 +124,46 @@ class OPTLearnedPositionalEmbedding(nn.Embedding):
         return super().forward(positions + self.offset)
 
 
+class BMMLeftInput_QK(nn.Identity):
+    ...
+
+
+class BMMRightInput_QK(nn.Identity):
+    ...
+
+
+class BMMOutput_QK(nn.Identity):
+    ...
+
+
+class BMMLeftInput_PV(nn.Identity):
+    ...
+
+
+class BMMRightInput_PV(nn.Identity):
+    ...
+
+
+class BMMOutput_PV(nn.Identity):
+    ...
+
+
+class QuantizableBatchMatMul(nn.Module):
+    """
+    Wrapper around torch.bmm with distinct inputs/output class
+    instances that could be quantized through SparseML recipe
+    """
+
+    def __init__(self, left_input_cls, right_input_cls, output_cls):
+        super().__init__()
+        self.left_input = left_input_cls()
+        self.right_input = right_input_cls()
+        self.output = output_cls()
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor):
+        return self.output(torch.bmm(self.left_input(a), self.right_input(b)))
+
+
 class OPTAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
@@ -153,6 +193,9 @@ class OPTAttention(nn.Module):
         self.v_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
         self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+
+        self.attn_weights_bmm = QuantizableBatchMatMul(BMMLeftInput_QK, BMMRightInput_QK, BMMOutput_QK)
+        self.attn_output_bmm = QuantizableBatchMatMul(BMMLeftInput_PV, BMMRightInput_PV, BMMOutput_PV)
 
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
         return tensor.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
@@ -212,7 +255,7 @@ class OPTAttention(nn.Module):
         value_states = value_states.view(*proj_shape)
 
         src_len = key_states.size(1)
-        attn_weights = torch.bmm(query_states, key_states.transpose(1, 2))
+        attn_weights = self.attn_weights_bmm(query_states, key_states.transpose(1, 2))
 
         if attn_weights.size() != (bsz * self.num_heads, tgt_len, src_len):
             raise ValueError(
@@ -256,7 +299,7 @@ class OPTAttention(nn.Module):
 
         attn_probs = nn.functional.dropout(attn_weights, p=self.dropout, training=self.training)
 
-        attn_output = torch.bmm(attn_probs, value_states)
+        attn_output = self.attn_output_bmm(attn_probs, value_states)
 
         if attn_output.size() != (bsz * self.num_heads, tgt_len, self.head_dim):
             raise ValueError(


### PR DESCRIPTION
This change enables quantization for torch.bmm in OPT models using SparseML recipe.

The wrapped MatMuls corresponding to (key, query) and (prob, value) pairs in an OPTDecoderLayer now look like:

```
        (11): OPTDecoderLayer(
          (self_attn): OPTAttention(
            <...>
            (attn_weights_bmm): QuantizableBatchMatMul(
              (left_input): BMMLeftInput_QK()
              (right_input): BMMRightInput_QK()
              (output): BMMOutput_QK()
            )
            (attn_output_bmm): QuantizableBatchMatMul(
              (left_input): BMMLeftInput_PV()
              (right_input): BMMRightInput_PV()
              (output): BMMOutput_PV()
            )
          )
          <...>

```
The quantization of these MatMuls can be performed individually on their inputs and outputs through recipes, as the following example:
```
    ignore: ["lm_head", "Embedding", "OPTLearnedPositionalEmbedding", "QuantizableBatchMatMul"]
    scheme_overrides:
      BMMLeftInput_QK:
        input_activations:
          num_bits: 8
          symmetric: True
        output_activations: null
      BMMRightInput_QK:
        input_activations:
          num_bits: 8
          symmetric: False
        output_activations: null
      BMMOutput_QK:
        input_activations: null
        output_activations: null
      BMMLeftInput_PV:
        input_activations:
          num_bits: 8
          symmetric: False
        output_activations: null
      BMMRightInput_PV:
        input_activations:
          num_bits: 8
          symmetric: True
        output_activations: null
      BMMOutput_PV:
        input_activations: null
        output_activations: null
```
The resulting layer portion after applying the above recipe looks like this:
```
            (attn_weights_bmm): QuantizableBatchMatMul(
              (left_input): QuantWrapper(
                (quant): QuantStub(
                  (activation_post_process): FakeQuantize(
                    fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8), quant_min=-128, quant_max=127, dtype=torch.qint8, qscheme=torch.per_tensor_symmetric, ch_axis=-1, scale=tensor([1.]), zero_point=tensor([0], dtype=torch.int32)
                    (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
                  )
                )
                (dequant): DeQuantStub()
                (module): BMMLeftInput_QK(
                  (activation_post_process): Identity()
                )
              )
              (right_input): QuantWrapper(
                (quant): QuantStub(
                  (activation_post_process): FakeQuantize(
                    fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8), quant_min=-128, quant_max=127, dtype=torch.qint8, qscheme=torch.per_tensor_affine, ch_axis=-1, scale=tensor([1.]), zero_point=tensor([0], dtype=torch.int32)
                    (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
                  )
                )
                (dequant): DeQuantStub()
                (module): BMMRightInput_QK(
                  (activation_post_process): Identity()
                )
              )
              (output): BMMOutput_QK(
                (activation_post_process): Identity()
              )
            )
            (attn_output_bmm): QuantizableBatchMatMul(
              (left_input): QuantWrapper(
                (quant): QuantStub(
                  (activation_post_process): FakeQuantize(
                    fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8), quant_min=-128, quant_max=127, dtype=torch.qint8, qscheme=torch.per_tensor_affine, ch_axis=-1, scale=tensor([1.]), zero_point=tensor([0], dtype=torch.int32)
                    (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
                  )
                )
                (dequant): DeQuantStub()
                (module): BMMLeftInput_PV(
                  (activation_post_process): Identity()
                )
              )
              (right_input): QuantWrapper(
                (quant): QuantStub(
                  (activation_post_process): FakeQuantize(
                    fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8), quant_min=-128, quant_max=127, dtype=torch.qint8, qscheme=torch.per_tensor_symmetric, ch_axis=-1, scale=tensor([1.]), zero_point=tensor([0], dtype=torch.int32)
                    (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
                  )
                )
                (dequant): DeQuantStub()
                (module): BMMRightInput_PV(
                  (activation_post_process): Identity()
                )
              )
              (output): BMMOutput_PV(
                (activation_post_process): Identity()
              )
```