### PR TITLE
compressed-tensors support for KV cache Quantization

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -26,6 +26,7 @@ from torch import nn
 
 from ..cache_utils import (
     Cache,
+    CompressedTensorsCache,
     DynamicCache,
     HQQQuantizedCache,
     QuantizedCacheConfig,
@@ -112,7 +113,11 @@ if is_accelerate_available():
     from accelerate.hooks import AlignDevicesHook, add_hook_to_module
 
 NEED_SETUP_CACHE_CLASSES_MAPPING = {"static": StaticCache, "sliding_window": SlidingWindowCache}
-QUANT_BACKEND_CLASSES_MAPPING = {"quanto": QuantoQuantizedCache, "HQQ": HQQQuantizedCache}
+QUANT_BACKEND_CLASSES_MAPPING = {
+    "quanto": QuantoQuantizedCache,
+    "HQQ": HQQQuantizedCache,
+    "compressed-tensors": CompressedTensorsCache,
+}
 
 
 @dataclass

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -115,6 +115,7 @@ from .import_utils import (
     is_bitsandbytes_available,
     is_bs4_available,
     is_coloredlogs_available,
+    is_compressed_tensors_available,
     is_cv2_available,
     is_cython_available,
     is_datasets_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -174,6 +174,7 @@ _torchdistx_available = _is_package_available("torchdistx")
 _torchvision_available = _is_package_available("torchvision")
 _mlx_available = _is_package_available("mlx")
 _hqq_available = _is_package_available("hqq")
+_is_compressed_tensors_available = _is_package_available("compressed_tensors")
 
 
 _torch_version = "N/A"
@@ -880,6 +881,10 @@ def is_safetensors_available():
 
 def is_tokenizers_available():
     return _tokenizers_available
+
+
+def is_compressed_tensors_available():
+    return _is_compressed_tensors_available
 
 
 @lru_cache


### PR DESCRIPTION
## Feature description

Implements quantized kv cache support for the transformer models that have been quantized using `compressed-tensors`.

Introduces: 
- `CompressedTensorsQuantizedCacheConfig` - a config object that stores the static qparams for quantizing/dequantizing KV Cache
- minor improvements to the `QuantizedCache` interface, to make it more general in the future for other implementations
- `CompressedTensorsCache` - very lightweight wrapper around `QuantizedCache`, that allows us to enable kv cache quantization

## Manual testing:

```python

from transformers import AutoTokenizer, AutoModelForCausalLM
from transformers.cache_utils import CompressedTensorsQuantizedCacheConfig
import torch
import time 
investigate_mem_consumption = True

model_id = "/root/compressed-tensors/llama1.1b_new_quant_out" # quantized model with kv cache quantization enabled

tokenizer = AutoTokenizer.from_pretrained("Xenova/llama2.c-stories15M") # somehow the tokenizer is missing from the model in `model_id`
tokenizer.pad_token_id = tokenizer.eos_token_id
model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="eager").to("cuda:0")

inputs = tokenizer("I like rock music because", return_tensors="pt").to(model.device)

cache_config = CompressedTensorsQuantizedCacheConfig.from_pretrained(model_id)

out_quant = model.generate(**inputs, cache_implementation="quantized", cache_config=cache_config, min_new_tokens=40, return_dict_in_generate=True)
out = model.generate(**inputs, min_new_tokens=40, return_dict_in_generate=True)

assert out_quant.sequences.allclose(out.sequences) # assert same tokens get generated regardless of cache type
assert out_quant.past_key_values._quantized_key_cache[-1].dtype == torch.int8 # assert that we are actually caching quantized tensors
```

## Note
Compatible with this branch of compressed-tensors: https://github.com/neuralmagic/compressed-tensors/pull/86
Pending missing items: Add tests, add `compressed-tensors` as transformers dependency, fix ugly import issues (circular imports between transformers and compressed-tensors)